### PR TITLE
Resolve bug with using base30 import

### DIFF
--- a/jSignature.js
+++ b/jSignature.js
@@ -1280,7 +1280,7 @@ var GlobalJSignatureObjectInitializer = function($){
 				, data
 				, formattype
 				, (function(jSignatureInstance){ 
-					return function(){ return jSignatureInstance.resetCanvas(arguments) }
+					return function(){ return jSignatureInstance.resetCanvas((typeof arguments[0] == 'object')? arguments[0] : arguments) }
 				})($canvas.data(apinamespace+'.this'))
 			)
 		}


### PR DESCRIPTION
When using setData for the base30 alias the arguments array has 2 items the data array and the callback function.
The result is that the DataEngine throws an exception when resetCanvas is called due to DataEngine not having the correct data (storageObject) instead it has the entire arguments array with index 0 being the data array.
