### PR TITLE
Fix TypeError in PubSubClass.unsubscribe

### DIFF
--- a/src/jSignature.js
+++ b/src/jSignature.js
@@ -114,6 +114,7 @@ var PubSubClass = function(context){
 			for (var i = 0, l = currentTopic.length; i < l; i++) {
 				if (currentTopic[i][0] === token.callback) {
 					currentTopic.splice(i, 1)
+					break
 				}
 			}
 		}


### PR DESCRIPTION
Modifying an array while iterating over it is tricky.  If we delete an
element in the middle and continue to iterate using the old length,
we'll perform an access beyond the end of the array, get back an
`undefined`, and then get a TypeError when we try to `[0]` it.

I've seen this in the wild, when attempting to show a popup that
embeds jSignature for the second time on the same page.  The
error is uncaught and disables all subsequent JavaScript on the
page.

I don't know if this method was meant to remove just the first matching
callback, or all of them.  My modification assumes the first; if you
need the second, instead of break do `i--; l--`.
